### PR TITLE
fix: 修正行事曆日期時區偏移與手機版按鈕樣式問題

### DIFF
--- a/2026/calendar.html
+++ b/2026/calendar.html
@@ -408,12 +408,9 @@
 
               function getGoogleCalendarURL(event) {
                 const start = event.date.replace(/-/g, "");
-                const nextDay = new Date(event.date + "T00:00:00");
-                nextDay.setDate(nextDay.getDate() + 1);
-                const end = nextDay
-                  .toISOString()
-                  .slice(0, 10)
-                  .replace(/-/g, "");
+                const [ey, em, ed] = event.date.split("-").map(Number);
+                const nextDay = new Date(ey, em - 1, ed + 1);
+                const end = `${nextDay.getFullYear()}${String(nextDay.getMonth() + 1).padStart(2, "0")}${String(nextDay.getDate()).padStart(2, "0")}`;
                 const text = encodeURIComponent(
                   event.title
                     ? `${event.community} - ${event.title}`
@@ -433,12 +430,9 @@
               function downloadICS(index) {
                 const event = currentMonthEvents[index];
                 const start = event.date.replace(/-/g, "");
-                const nextDay = new Date(event.date + "T00:00:00");
-                nextDay.setDate(nextDay.getDate() + 1);
-                const end = nextDay
-                  .toISOString()
-                  .slice(0, 10)
-                  .replace(/-/g, "");
+                const [ey, em, ed] = event.date.split("-").map(Number);
+                const nextDay = new Date(ey, em - 1, ed + 1);
+                const end = `${nextDay.getFullYear()}${String(nextDay.getMonth() + 1).padStart(2, "0")}${String(nextDay.getDate()).padStart(2, "0")}`;
                 const summary = event.title
                   ? `${event.community} - ${event.title}`
                   : event.community;

--- a/index.css
+++ b/index.css
@@ -637,7 +637,14 @@ ul {
     .btn-cal-group {
       display: flex;
       flex-direction: column;
-      gap: 4px;
+      gap: 8px;
+    }
+
+    .btn-cal {
+      padding: 8px 12px;
+      font-size: 0.9rem;
+      min-height: 40px;
+      width: 100%;
     }
 
     th:nth-child(1),


### PR DESCRIPTION
## 摘要

- 修正 Google 行事曆與 ICS 下載的結束日期時區偏移問題：改用本地時間建構日期，避免跨時區時日期計算錯誤
- 修正手機版行事曆下載按鈕過小且間距不足問題：調整 `.btn-cal-group` 間距為 8px，並設定 `.btn-cal` 最小高度與寬度

## 測試計畫

- [ ] 確認 Google 行事曆連結的結束日期正確（不早一天）
- [ ] 確認 ICS 下載的結束日期正確
- [ ] 在手機裝置上確認下載按鈕大小與間距正常
- [ ] 確認桌面版樣式未受影響

🤖 Generated with [Claude Code](https://claude.ai/claude-code)