### PR TITLE
feat: 新增 MCP 伺服器與 OpenAPI 整合並完善範本化文件

### DIFF
--- a/2026/data.json
+++ b/2026/data.json
@@ -4,49 +4,57 @@
       "name": "Google Developer Groups Kaohsiung 臉書社團",
       "link": "https://www.facebook.com/groups/GDGKaohsiung",
       "logo": "../assets/logo_gdg_kaohsiung.png",
-      "description": "介紹：<br>Google Developer Groups Kaohsiung 前身是 Android 高雄開發者社群，誕生於 2014 年 3 月。<br><br>我們每年定期舉辦 Build with AI、 Google I/O Extended、DevFest 和 TOOCON 天黑黑月會，希望讓高雄對軟體開發有興趣的朋友能夠有實體交流的機會。<br><br>歡迎加入 Google Developer Groups Kaohsiung 粉絲專業頁和 GDG Kaohsiung 臉書社團，掌握最新活動資訊。"
+      "description": "介紹：<br>Google Developer Groups Kaohsiung 前身是 Android 高雄開發者社群，誕生於 2014 年 3 月。<br><br>我們每年定期舉辦 Build with AI、 Google I/O Extended、DevFest 和 TOOCON 天黑黑月會，希望讓高雄對軟體開發有興趣的朋友能夠有實體交流的機會。<br><br>歡迎加入 Google Developer Groups Kaohsiung 粉絲專業頁和 GDG Kaohsiung 臉書社團，掌握最新活動資訊。",
+      "color": "#EA4335"
     },
     {
       "name": "開發者 Buffet Discord",
       "link": "https://discord.gg/uRvhqpFeuG",
       "logo": "../assets/logo_developer_buffet_v2.png",
-      "description": "介紹：<br>我們是一群在台灣科技研討會結識的夥伴，自疫情期間，我們所在的城市技術社群與聚會逐漸減少。希望能保持討論和交流的熱度，因此我們決定發起聚會。 在這裏會舉辦各種形式的活動，議題大致上包括但不限於前、後端、UI/UX、ML、軟體開發等，希望大家能在這裡找到並盡情享受自己感興趣的事物，因此取名為【開發者 Buffet】。<br><br>目前有線下活動【開發者 café】每月的最後一個周二晚上 19:00 - 21:00，在高雄的咖啡廳與最多 10 位左右的開發者們一起輕鬆聊聊天，歡迎任何主題 ☕<br><br>以及我們也有不定期舉辦線上讀書會，你可以在 Discord 找到更多詳細資訊，歡迎加入 \uD83D\uDE4C"
+      "description": "介紹：<br>我們是一群在台灣科技研討會結識的夥伴，自疫情期間，我們所在的城市技術社群與聚會逐漸減少。希望能保持討論和交流的熱度，因此我們決定發起聚會。 在這裏會舉辦各種形式的活動，議題大致上包括但不限於前、後端、UI/UX、ML、軟體開發等，希望大家能在這裡找到並盡情享受自己感興趣的事物，因此取名為【開發者 Buffet】。<br><br>目前有線下活動【開發者 café】每月的最後一個周二晚上 19:00 - 21:00，在高雄的咖啡廳與最多 10 位左右的開發者們一起輕鬆聊聊天，歡迎任何主題 ☕<br><br>以及我們也有不定期舉辦線上讀書會，你可以在 Discord 找到更多詳細資訊，歡迎加入 🙌",
+      "color": "#4285F4"
     },
     {
       "name": "國泰 CDC 小聚",
       "link": "https://lit.link/zh-tw/cdc0413",
       "logo": "../assets/logo_cdc_v3.png",
-      "description": "介紹：<br>\uD83C\uDF1F 國泰 CDC 小聚<br>中南部領航 FinTech 新浪潮！<br><br>國泰 CDC 小聚是專注於金融科技（FinTech）與雲端技術的技術型社群。中南部雙據點致力於推動數位轉型與全球化佈局！<br><br>\uD83C\uDF1E 台中 CDC ✈\uFE0F 海外數位基地 ✈\uFE0F<br>打造中部首座金融科技新地標，進駐台灣中部首座國際物流產業基地。台中 CDC 目標是支援集團的國際化發展並負責負責資訊服務與基礎架構規劃。<br><br>\uD83D\uDEA2 高雄 CDC ☁\uFE0F 雲端轉型基地 ☁\uFE0F<br>坐落在高雄亞灣區黃金地段，面向一整面尊爵不凡的無敵海景。高雄 CDC 專注於雲端轉型任務，包含核心及周邊上雲架構及開發，以及雲端服務應用評估及導入。<br><br>國泰 CDC 小聚將於台中與高雄不定期舉辦實體技術 Meetup，未來也會有更多不同形式的交流活動。如果你是想要南漂、北漂或台中、高雄在地的工程師，或關注金融科技與雲端發展的朋友，那走過路過不要錯過！在這裡，你不僅可以學習成長，也可以找到無限的機會和發展前景，歡迎透過國泰 CDC 小聚與我們交流～"
+      "description": "介紹：<br>🌟 國泰 CDC 小聚<br>中南部領航 FinTech 新浪潮！<br><br>國泰 CDC 小聚是專注於金融科技（FinTech）與雲端技術的技術型社群。中南部雙據點致力於推動數位轉型與全球化佈局！<br><br>🌞 台中 CDC ✈️ 海外數位基地 ✈️<br>打造中部首座金融科技新地標，進駐台灣中部首座國際物流產業基地。台中 CDC 目標是支援集團的國際化發展並負責負責資訊服務與基礎架構規劃。<br><br>🚢 高雄 CDC ☁️ 雲端轉型基地 ☁️<br>坐落在高雄亞灣區黃金地段，面向一整面尊爵不凡的無敵海景。高雄 CDC 專注於雲端轉型任務，包含核心及周邊上雲架構及開發，以及雲端服務應用評估及導入。<br><br>國泰 CDC 小聚將於台中與高雄不定期舉辦實體技術 Meetup，未來也會有更多不同形式的交流活動。如果你是想要南漂、北漂或台中、高雄在地的工程師，或關注金融科技與雲端發展的朋友，那走過路過不要錯過！在這裡，你不僅可以學習成長，也可以找到無限的機會和發展前景，歡迎透過國泰 CDC 小聚與我們交流～",
+      "color": "#34a853"
     },
     {
       "name": "高雄 WordPress 小聚 Kaohsiung WordPress Meetup",
       "link": "https://www.meetup.com/kaohsiung-wordpress-meetup/",
       "logo": "../assets/logo_kaohsiung_word_press_v2.png",
-      "description": "介紹：<br>我們是一群位於高雄的 WordPress 愛好者，我們之中包含了開發者、設計師、內容產製者以及各式各樣與 WordPress 相關的人。<br><br>藉由這個社群，我們希望能夠與同樣對 WordPress 有興趣的你，分享我們的想法與經驗。<br><br>這個 WordPress Meetup Group 竭誠歡迎所有喜愛 WordPress 的人們加入。"
+      "description": "介紹：<br>我們是一群位於高雄的 WordPress 愛好者，我們之中包含了開發者、設計師、內容產製者以及各式各樣與 WordPress 相關的人。<br><br>藉由這個社群，我們希望能夠與同樣對 WordPress 有興趣的你，分享我們的想法與經驗。<br><br>這個 WordPress Meetup Group 竭誠歡迎所有喜愛 WordPress 的人們加入。",
+      "color": "#4285F4"
     },
     {
       "name": "Second Space 臉書社團",
       "link": "https://www.facebook.com/cubeworksx",
       "logo": "../assets/logo_second_space.png",
-      "description": "介紹：<br>Second Space —  24/7 members club designed for active creators in tech and design industry.  It’s a workspace during the day and a social venue at night with events ranging from technical workshops, courses, hackathons and design meetups to leadership and personal development sessions. Second Space is a bilingual club with focus international tech talents, digital nomads and with local professional communities."
+      "description": "介紹：<br>Second Space —  24/7 members club designed for active creators in tech and design industry.  It’s a workspace during the day and a social venue at night with events ranging from technical workshops, courses, hackathons and design meetups to leadership and personal development sessions. Second Space is a bilingual club with focus international tech talents, digital nomads and with local professional communities.",
+      "color": "#F9AB00"
     },
     {
       "name": "KaLUG 官方網站",
       "link": "https://kalug.tw/",
       "logo": "../assets/logo_kalug.jpg",
-      "description": "介紹：<br>KaLUG - Kaohsiung Linux User Group: 由一群熱愛 Linux / open source 的高雄人所組成的社群"
+      "description": "介紹：<br>KaLUG - Kaohsiung Linux User Group: 由一群熱愛 Linux / open source 的高雄人所組成的社群",
+      "color": "#4285F4"
     },
     {
       "name": "Pyladies Kaohsiung 官網",
       "link": "https://kaohsiung.pyladies.com/",
       "logo": "../assets/logo_pyladies_kh.png",
-      "description": "介紹：<br>PyLadies Kaohsiung 是 PyLadies 國際組織的一員，以高雄為基地推動女性技術社群的發展，致力於打造讓女性能安心、自信地學習、交流與成長的環境。舉辦各種工作坊、經驗分享等交流活動，讓女性能透過 Python 提升技術、拓展人脈與視野，進而在科技領域中成為主動的參與者與領導者。同時也積極與在地及全台社群建立連結、相互支持，讓整體技術社群更加茁壯。"
+      "description": "介紹：<br>PyLadies Kaohsiung 是 PyLadies 國際組織的一員，以高雄為基地推動女性技術社群的發展，致力於打造讓女性能安心、自信地學習、交流與成長的環境。舉辦各種工作坊、經驗分享等交流活動，讓女性能透過 Python 提升技術、拓展人脈與視野，進而在科技領域中成為主動的參與者與領導者。同時也積極與在地及全台社群建立連結、相互支持，讓整體技術社群更加茁壯。",
+      "color": "#FA3C0A"
     },
     {
       "name": "KIMU 高雄獨立遊戲開發者聚會 臉書社團",
       "link": "https://www.facebook.com/groups/kimugroup/",
       "logo": "../assets/logo_kimu.png",
-      "description": "介紹：<br>KIMU 高雄獨立遊戲開發者聚會為 IGDA Taiwan 所屬 SIG（Special Interesting Group)，以高雄為據點在南台灣推動獨立遊戲開發交流活動的非營利組織，我們長期舉辦工作坊、Game Jam 以及分享會，不管您是業界、教育界、學生或遊戲愛好者，只要您對獨立遊戲開發感興趣，都歡迎您來參加。"
+      "description": "介紹：<br>KIMU 高雄獨立遊戲開發者聚會為 IGDA Taiwan 所屬 SIG（Special Interesting Group)，以高雄為據點在南台灣推動獨立遊戲開發交流活動的非營利組織，我們長期舉辦工作坊、Game Jam 以及分享會，不管您是業界、教育界、學生或遊戲愛好者，只要您對獨立遊戲開發感興趣，都歡迎您來參加。",
+      "color": "#34A853"
     },
     {
       "name": "南台灣敏捷社群 臉書社團",
@@ -58,25 +66,29 @@
       "name": "K.NET",
       "link": "https://www.facebook.com/k.net.io",
       "logo": "../assets/logo_k_net.png",
-      "description": "介紹：<br>從高雄發芽dot NET技術社群，有空歡迎您來坐坐，交流交流，<br>每週一晚上於星巴克聚會，有空可以來坐坐認識新朋友，<br>常態聚會地點：裕誠路台銀旁星巴克"
+      "description": "介紹：<br>從高雄發芽dot NET技術社群，有空歡迎您來坐坐，交流交流，<br>每週一晚上於星巴克聚會，有空可以來坐坐認識新朋友，<br>常態聚會地點：裕誠路台銀旁星巴克",
+      "color": "#F9AB00"
     },
     {
       "name": "VSCP 粉鳥趴",
       "link": "https://www.facebook.com/groups/vscp.tw",
       "logo": "../assets/logo_vscp.png",
-      "description": "介紹：<br>核心理念：<br>像鴿子一樣，在都市環境中建立穩定、互助的工作者社群，透過輕鬆聚會，促進實質的知識交流、資源分享和協作機會。<br>目標參與者：<br>・主要群體：AI 時代的獨立工作者（無論是現職或是目標）<br>・共同特徵：<br>- 同時具備技術與商業思維<br>- 需要經營個人或工作室的實務知識<br>- 尋求協作夥伴和資源網絡<br>- 重視工作氛圍和生活品質"
+      "description": "介紹：<br>核心理念：<br>像鴿子一樣，在都市環境中建立穩定、互助的工作者社群，透過輕鬆聚會，促進實質的知識交流、資源分享和協作機會。<br>目標參與者：<br>・主要群體：AI 時代的獨立工作者（無論是現職或是目標）<br>・共同特徵：<br>- 同時具備技術與商業思維<br>- 需要經營個人或工作室的實務知識<br>- 尋求協作夥伴和資源網絡<br>- 重視工作氛圍和生活品質",
+      "color": "#F9AB00"
     },
     {
       "name": "UIUX.Kaohsiung",
       "link": "https://luma.com/uiux.kaohsiung",
       "logo": "../assets/logo_uiux_kaohsiung.png",
-      "description": "介紹：<br>嗨！高雄的朋友們 \uD83D\uDC4B 我們是高雄 UIUX 社群，這是個輕鬆的設計師互助聚會。<br>每個月都有不同主題，會根據上次討論決定下個月的題目，鄰近活動會再更新題目與圖片，盡請期待"
+      "description": "介紹：<br>嗨！高雄的朋友們 👋 我們是高雄 UIUX 社群，這是個輕鬆的設計師互助聚會。<br>每個月都有不同主題，會根據上次討論決定下個月的題目，鄰近活動會再更新題目與圖片，盡請期待",
+      "color": "#34A853"
     },
     {
       "name": "vLAB Online 台灣路由網路實驗中心",
       "link": "http://www.vlab.tw",
       "logo": "../assets/logo_vlab.png",
-      "description": "介紹：<br>vLAB Online 自 2000 年創立以來，歷經網站、論壇到 Line 群組等不同型態的發展。第一代以網站型態奠定中文網路技術交流基礎；第二代透過論壇累積大量技術文章與社群能量；之後隨著交流模式轉變，逐步轉型為以 Line 群組為核心的即時互助社群。自 2024 年第三代重起以來，vLAB 除了持續經營社群交流，也陸續啟用社群資源平台、推出帶狀活動、建立臨時與正式官方網站、重啟多個社群媒體平台，並透過 Workshop、Meetup 及大型活動拓展社群影響力。2026 年 1 月正式啟用官方網站。"
+      "description": "介紹：<br>vLAB Online 自 2000 年創立以來，歷經網站、論壇到 Line 群組等不同型態的發展。第一代以網站型態奠定中文網路技術交流基礎；第二代透過論壇累積大量技術文章與社群能量；之後隨著交流模式轉變，逐步轉型為以 Line 群組為核心的即時互助社群。自 2024 年第三代重起以來，vLAB 除了持續經營社群交流，也陸續啟用社群資源平台、推出帶狀活動、建立臨時與正式官方網站、重啟多個社群媒體平台，並透過 Workshop、Meetup 及大型活動拓展社群影響力。2026 年 1 月正式啟用官方網站。",
+      "color": "#4285F4"
     }
   ],
   "sponsors": [

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 AndyAWD and contributors
+Copyright (c) 2026 AndyAWD and GDG Kaohsiung contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 AndyAWD and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 這是一個基於「有趣」而誕生的開源專案，旨在讓每一位參與高雄在地技術社群的成員，都能擁有一個屬於自己的「社群名牌卡」，並透過數位集章的方式，紀錄一整年的社群歷程。
 
+本專案同時被設計為**可被其他城市/組織 fork 的範本**（例：台北社群卡、台中社群卡），詳情請見下方 [🍴 Fork 與客製化指南](#-fork-與客製化指南給其他城市組織)。
+
 ---
 
 ## 💡 專案特色
@@ -10,22 +12,111 @@
 *   **📅 高雄社群月曆**：整合大高雄地區各項軟體、技術與設計社群的活動資訊，讓你不再錯過任何精彩聚會。
 *   **🎁 集章獎勵**：參與活動並收集印章，解鎖專屬的社群成就與獎勵。
 *   **🤝 社群與贊助商介紹**：快速認識高雄在地的活躍社群與支持技術發展的贊助夥伴。
+*   **🤖 AI 友善**：同時提供 OpenAPI 規格與 MCP 伺服器，讓 AI 助理可以直接查詢資料、甚至代為發 Pull Request。
+
+---
+
+## 🪪 集章與印章機制
+
+*   **印章圖檔**：位於 `assets/stamps/`，依社群命名（例如 `seal_toocon.png`、`seal_developer_buffet_blue.png`）。
+*   **使用方式**：於 `2026/index.html` 點擊印章按鈕，再點卡片對應位置即可蓋章；點擊「清除印章」可重置。
+*   **下載**：完成集章後可下載高解析度紀念圖檔。
+*   **新增/替換印章**（給 fork 者）：把 PNG 放入 `assets/stamps/`，依社群命名規則對應到 `2026/data.json` 中的社群即可。
+
+---
+
+## 🛠️ 本機開發與部署
+
+### 環境需求
+
+*   Node.js ≥ 18
+
+### 安裝與啟動
+
+```bash
+# 安裝相依套件（主要供 OG 圖產生用）
+npm install
+
+# 產生 Open Graph 圖片
+npm run generate-og
+```
+
+本專案是純靜態網站，直接用瀏覽器打開 `2026/index.html` 就能預覽。
+
+### 部署
+
+採用 **GitHub Pages** 部署：
+
+*   根目錄的 `CNAME` 檔指定自訂網域（原專案為 `community-card.org`）。
+*   若 fork 後沒有自訂網域，**請刪除 `CNAME`**，直接使用 `<user>.github.io/<repo>` 即可。
+
+### 資料夾結構速覽
+
+| 路徑 | 說明 |
+|---|---|
+| `2026/index.html`、`2026/sponsors.html` | 該年度頁面 |
+| `2026/data.json` | 社群、贊助商、獎勵資料 |
+| `2026/events.json` | 活動行事曆 |
+| `2025/` | 前一年度封存 |
+| `assets/stamps/` | 印章圖檔 |
+| `mcp/` | MCP 伺服器 |
+| `openapi.yaml` | OpenAPI 規格 |
+| `scripts/generate-og-images.js` | OG 圖產生器 |
 
 ---
 
 ## 🚀 如何參與與協作
 
-想要在社群卡片上顯示你的社群 Logo 或是將活動加入行事曆嗎？我們非常歡迎你的加入！
+我們歡迎兩種參與情境：
 
-你可以透過以下方式參與：
-1.  **提交 Pull Request (PR)**：直接 Fork 本專案並提交你的修改。
-2.  **填寫表單**：透過我們的 [線上表單](https://forms.gle/38EgveLNs8WdKT5v7) 提交資訊。
+### A. 對本專案貢獻（高雄社群活動 / 印章 / 功能）
+
+1.  **Fork 本專案**並建立分支。
+2.  視需求修改下列檔案：
+    *   新增活動 → 編輯 `2026/events.json`（注意 `description` **不能超過 20 個字**，詳見下方 [資料 Schema](#資料-schema-速查)）。
+    *   新增社群 → 編輯 `2026/data.json` 的 `communities`。
+    *   新增印章 → 放 PNG 到 `assets/stamps/`。
+3.  本機用瀏覽器開啟 `2026/index.html` 確認顯示無誤。
+4.  發送 Pull Request。
+
+或透過 [線上表單](https://forms.gle/38EgveLNs8WdKT5v7) 提交資訊。
+
+### B. Fork 為自己城市/組織使用
+
+請參考下方 [🍴 Fork 與客製化指南](#-fork-與客製化指南給其他城市組織)。
+
+---
+
+## 🍴 Fork 與客製化指南（給其他城市/組織）
+
+想用這個專案做「台北社群卡」、「台中社群卡」、或公司內部活動集章卡嗎？以下是 fork 後需要客製化的清單：
+
+| # | 檔案 | 位置/欄位 | 改成什麼 |
+|---|---|---|---|
+| 1 | `README.md` | 所有 `YOUR_GITHUB_USERNAME` | 你的 GitHub 帳號或組織名稱 |
+| 2 | `openapi.yaml` | `servers[0].url` | 你的 GitHub Pages 網址（例 `https://your-domain.com` 或 `https://yourname.github.io/YourRepo`） |
+| 3 | `CNAME` | 整個內容 | 你的自訂網域；若無自訂網域可**刪除此檔** |
+| 4 | `package.json` | `name`、`description` | 你的專案資訊 |
+| 5 | `LICENSE` | 版權人 | 加上自己的姓名/組織（建議保留原作者欄位） |
+| 6 | `2026/data.json` | `communities`、`sponsors`、`rewards` | 你的城市的社群資料 |
+| 7 | `2026/events.json` | 全部 | 你的城市的活動資料 |
+| 8 | `assets/stamps/` | PNG 檔 | 你的城市的印章設計 |
+| 9 | `mcp/index.js` | 第 10 行 `name: "kaohsiung-community-mcp"` | 改成你的城市，例如 `taipei-community-mcp` |
+| 10 | `mcp/package.json` | `name` | 改成例如 `taipei-community-card-mcp` |
+
+### 資料更新工作流
+
+Fork 後若只是要定期維護自家社群的活動，建議流程：
+
+1.  每月固定更新 `events.json`。
+2.  Push 到 main 分支，GitHub Pages 會自動部署。
+3.  若想讓 AI 自動發 PR 新增活動，請參考下方 MCP 段落設定 `GITHUB_TOKEN`。
 
 ---
 
 ## 🤖 給 AI 助理與開發者的整合指南 (AI Integrations)
 
-本專案不僅服務人類開發者，更支援外部 AI 助理（如 Gemini、Claude、ChatGPT 等）直接讀取高雄在地技術社群資訊與活動行事曆，甚至允許授權的 AI 自動發起 Pull Request 來新增活動！
+本專案不僅服務人類開發者，更支援外部 AI 助理（如 Gemini、Claude、ChatGPT 等）直接讀取在地技術社群資訊與活動行事曆，甚至允許授權的 AI 自動發起 Pull Request 來新增活動！
 
 我們提供兩種無伺服器 (Serverless) 的整合方式：
 
@@ -48,40 +139,124 @@
 
     *(設定完成後，AI 就能自動看懂並呼叫 `/2026/data.json` 與 `/2026/events.json` 取得最新活動資訊！)*
 
+#### 資料 Schema 速查
+
+詳細欄位定義請看 [`openapi.yaml`](./openapi.yaml)，以下為摘要：
+
+**`/2026/data.json`** 結構：
+
+| 區塊 | 欄位 | 型別 | 必填 | 說明/約束 |
+|---|---|---|---|---|
+| `communities[]` | `name` | string | ✓ | 社群名稱 |
+| | `link` | string (URI) | – | 社群連結 |
+| | `logo` | string | – | Logo 圖檔路徑或 URL |
+| | `description` | string | – | 社群介紹 |
+| | `color` | string | – | hex 代表色，例如 `#EA4335` |
+| `sponsors[]` | `name` / `link` / `logo` / `description` | string | – | 贊助商（同上但無 `color`） |
+| `rewards[]` | `name` / `link` / `logo` / `description` | string | – | 集章獎勵項目 |
+
+**`/2026/events.json`**（陣列，每筆為一個活動物件）：
+
+| 欄位 | 型別 | 必填 | 約束 |
+|---|---|---|---|
+| `date` | string | ✓ | `YYYY-MM-DD`，例如 `2026-05-15` |
+| `community` | string | ✓ | 主辦社群名稱（需對應 `communities[].name`） |
+| `title` | string | ✓ | 活動標題 |
+| `description` | string | – | **最多 20 個字**（與 MCP `propose_new_event` 限制一致） |
+| `link` | string | – | 報名/詳情連結 |
+| `color` | string | ✓ | hex 顏色，應對應主辦社群代表色 |
+
+JSON 範例：
+
+```json
+{
+  "date": "2026-06-09",
+  "community": "GDG Kaohsiung",
+  "title": "TOOCON #42",
+  "description": "使用 Skills 打造 AI CLI 設定精靈",
+  "link": "https://gdg.community.dev/e/m8qd55/",
+  "color": "#EA4335"
+}
+```
+
 ### 2. 透過 MCP 伺服器 (Model Context Protocol) - 適合各類 AI 開發工具
 
 我們在 `mcp/` 目錄下實作了一個 Node.js MCP 伺服器腳本。你不需要把專案 clone 下來，只需要透過 `npx` 指令就能在自己的電腦上讓 AI 工具直接連線本專案資料。
 
-*   **特色功能**：
-    *   `get_communities`: 查詢社群介紹。
-    *   `get_events`: 查詢活動行事曆。
-    *   `propose_new_event` **(需認證)**: 讓 AI 幫忙發送 Pull Request 新增活動。
+#### 可用工具
 
-*   **如何使用：**
-    所有工具的連線設定都是相同的，只需要將以下設定寫入各個工具的設定檔中。
+| 工具 | 參數 | 權限 | 說明 |
+|---|---|---|---|
+| `get_communities` | 無 | 唯讀 | 取得社群清單與介紹 |
+| `get_events` | `month`（選填，格式 `YYYY-MM`） | 唯讀 | 取得活動行事曆，可依月份過濾 |
+| `propose_new_event` | `date`、`title`、`community`、`description`（≤20 字）、`link` | **需 GitHub Token** | 自動建立 PR 新增活動 |
 
-    **通用設定 JSON**：
-    ```json
-    {
-      "mcpServers": {
-        "kaohsiung-community": {
-          "command": "npx",
-          "args": [
-            "-y",
-            "github:YOUR_GITHUB_USERNAME/CommunityCardOrg#main",
-            "mcp"
-          ],
-          "env": {
-            "GITHUB_TOKEN": "如果你希望 AI 能幫忙發 PR 新增活動，請填入你的 Personal Access Token",
-            "GITHUB_REPO_OWNER": "YOUR_GITHUB_USERNAME",
-            "GITHUB_REPO_NAME": "CommunityCardOrg"
-          }
-        }
+#### 環境變數
+
+| 變數 | 必填 | 說明 |
+|---|---|---|
+| `GITHUB_TOKEN` | 僅 `propose_new_event` 需要 | 需有目標 repo `repo` 權限的 Personal Access Token |
+| `GITHUB_REPO_OWNER` | 僅 `propose_new_event` 需要 | 目標 repo 擁有者（例：`AndyAWD`） |
+| `GITHUB_REPO_NAME` | 僅 `propose_new_event` 需要 | 目標 repo 名稱（預設 `CommunityCardOrg`） |
+
+#### 安裝設定
+
+所有 AI 工具的連線設定都是相同的，只需要將以下設定寫入各個工具的設定檔中：
+
+**通用設定 JSON**：
+
+```json
+{
+  "mcpServers": {
+    "kaohsiung-community": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "github:YOUR_GITHUB_USERNAME/CommunityCardOrg#main",
+        "mcp"
+      ],
+      "env": {
+        "GITHUB_TOKEN": "（選填）若希望 AI 能發 PR 新增活動，請填入你的 Personal Access Token",
+        "GITHUB_REPO_OWNER": "YOUR_GITHUB_USERNAME",
+        "GITHUB_REPO_NAME": "CommunityCardOrg"
       }
     }
-    ```
-    *(⚠️ 注意：請將 `YOUR_GITHUB_USERNAME` 替換為實際存放此專案的 GitHub 帳號)*
+  }
+}
+```
 
-    *   **Gemini CLI**: 請將上述設定加入 `~/.gemini/mcp.json` 中。
-    *   **Claude Code**: 請透過指令 `claude mcp add` 或是手動將設定加入 `claude_desktop_config.json` 中。
-    *   **Codex CLI**: 可以在專案的 `.codex/mcp.json` 或全域設定檔中加入上述設定。
+*(⚠️ 注意：請將 `YOUR_GITHUB_USERNAME` 替換為實際存放此專案的 GitHub 帳號；fork 者請改為自己的帳號與 repo 名稱。)*
+
+各工具的設定檔位置：
+
+*   **Claude Code**：執行 `claude mcp add` 互動式新增，或手動把上述 JSON 加到 `~/.claude.json`（全域）或專案的 `.mcp.json`。
+*   **Gemini CLI**：把設定加到 `~/.gemini/settings.json` 的 `mcpServers` 區塊。
+*   **Codex CLI**：把設定加到 `~/.codex/config.toml` 的 `[mcp_servers.kaohsiung-community]` 區段，或專案 `.codex/mcp.json`。
+
+#### 驗證安裝
+
+最快的本機驗證：
+
+```bash
+cd mcp
+npm install
+node index.js
+# 應印出：Kaohsiung Community MCP Server running on stdio
+```
+
+在各 AI 工具中驗證：
+
+*   **Claude Code**：對話中輸入 `/mcp` 應看到 `kaohsiung-community` 狀態為 `connected`。
+*   **Gemini CLI**：輸入 `/mcp` 或 `/tools` 應列出 `get_communities`、`get_events`、`propose_new_event`。
+*   **Codex CLI**：輸入 `/mcp` 或 `mcp list` 確認連線狀態。
+
+若連線失敗，最常見原因：
+1.  Node.js 版本低於 18。
+2.  MCP 設定 JSON 格式錯誤（多了逗號、引號等）。
+3.  Fork 後忘了把 `YOUR_GITHUB_USERNAME` 改成自己的帳號，導致 `npx` 抓不到 repo。
+
+---
+
+## 📜 授權
+
+本專案採 [MIT License](./LICENSE) 授權，歡迎自由使用、修改、散布。Fork 者請保留原作者欄位並可在 `LICENSE` 中追加自己的姓名/組織。

--- a/README.md
+++ b/README.md
@@ -1,0 +1,87 @@
+# 🌟 高雄社群名牌卡 (Kaohsiung Community Card)
+
+這是一個基於「有趣」而誕生的開源專案，旨在讓每一位參與高雄在地技術社群的成員，都能擁有一個屬於自己的「社群名牌卡」，並透過數位集章的方式，紀錄一整年的社群歷程。
+
+---
+
+## 💡 專案特色
+
+*   **🪪 數位名牌卡與集章體驗**：線上挑選專屬印章，點擊卡片即可輕鬆蓋章，並支援下載高解析度紀念圖檔。
+*   **📅 高雄社群月曆**：整合大高雄地區各項軟體、技術與設計社群的活動資訊，讓你不再錯過任何精彩聚會。
+*   **🎁 集章獎勵**：參與活動並收集印章，解鎖專屬的社群成就與獎勵。
+*   **🤝 社群與贊助商介紹**：快速認識高雄在地的活躍社群與支持技術發展的贊助夥伴。
+
+---
+
+## 🚀 如何參與與協作
+
+想要在社群卡片上顯示你的社群 Logo 或是將活動加入行事曆嗎？我們非常歡迎你的加入！
+
+你可以透過以下方式參與：
+1.  **提交 Pull Request (PR)**：直接 Fork 本專案並提交你的修改。
+2.  **填寫表單**：透過我們的 [線上表單](https://forms.gle/38EgveLNs8WdKT5v7) 提交資訊。
+
+---
+
+## 🤖 給 AI 助理與開發者的整合指南 (AI Integrations)
+
+本專案不僅服務人類開發者，更支援外部 AI 助理（如 Gemini、Claude、ChatGPT 等）直接讀取高雄在地技術社群資訊與活動行事曆，甚至允許授權的 AI 自動發起 Pull Request 來新增活動！
+
+我們提供兩種無伺服器 (Serverless) 的整合方式：
+
+### 1. 透過靜態 API (OpenAPI) - 適合各大主流 AI 模型
+
+本專案提供符合標準的 `openapi.yaml` 規格檔，讓 AI 能直接讀取 GitHub Pages 上的靜態 JSON 資料。
+
+*   **規格檔位置**：[`/openapi.yaml`](./openapi.yaml)
+*   **如何使用：**
+    *   **Gemini (Gems)**:
+        1. 在 Gemini 中建立一個自訂 Gem。
+        2. 在擴充功能 (Extensions) 或是動作 (Actions) 設定中新增一個 OpenAPI 動作。
+        3. 貼上我們專案中的 `openapi.yaml` 內容。
+    *   **Claude**:
+        目前 Claude 網頁版尚未原生支援匯入 OpenAPI 規格，但你可以直接將 `openapi.yaml` 的網址貼給 Claude，並請它依照規格呼叫 API。
+    *   **ChatGPT (Custom GPTs)**:
+        1. 在 ChatGPT 建立一個自訂 GPT。
+        2. 在 Configure > Actions 中點擊 "Create new action"。
+        3. 貼上我們專案中的 `openapi.yaml` 內容。
+
+    *(設定完成後，AI 就能自動看懂並呼叫 `/2026/data.json` 與 `/2026/events.json` 取得最新活動資訊！)*
+
+### 2. 透過 MCP 伺服器 (Model Context Protocol) - 適合各類 AI 開發工具
+
+我們在 `mcp/` 目錄下實作了一個 Node.js MCP 伺服器腳本。你不需要把專案 clone 下來，只需要透過 `npx` 指令就能在自己的電腦上讓 AI 工具直接連線本專案資料。
+
+*   **特色功能**：
+    *   `get_communities`: 查詢社群介紹。
+    *   `get_events`: 查詢活動行事曆。
+    *   `propose_new_event` **(需認證)**: 讓 AI 幫忙發送 Pull Request 新增活動。
+
+*   **如何使用：**
+    所有工具的連線設定都是相同的，只需要將以下設定寫入各個工具的設定檔中。
+
+    **通用設定 JSON**：
+    ```json
+    {
+      "mcpServers": {
+        "kaohsiung-community": {
+          "command": "npx",
+          "args": [
+            "-y",
+            "github:YOUR_GITHUB_USERNAME/CommunityCardOrg#main",
+            "mcp"
+          ],
+          "env": {
+            "GITHUB_TOKEN": "如果你希望 AI 能幫忙發 PR 新增活動，請填入你的 Personal Access Token",
+            "GITHUB_REPO_OWNER": "YOUR_GITHUB_USERNAME",
+            "GITHUB_REPO_NAME": "CommunityCardOrg"
+          }
+        }
+      }
+    }
+    ```
+    *(⚠️ 注意：請將 `YOUR_GITHUB_USERNAME` 替換為實際存放此專案的 GitHub 帳號)*
+
+    *   **Gemini CLI**: 請將上述設定加入 `~/.gemini/mcp.json` 中。
+    *   **Claude Code**: 請透過指令 `claude mcp add` 或是手動將設定加入 `claude_desktop_config.json` 中。
+    *   **Codex CLI**: 可以在專案的 `.codex/mcp.json` 或全域設定檔中加入上述設定。

--- a/conductor/mcp-and-openapi-plan.md
+++ b/conductor/mcp-and-openapi-plan.md
@@ -1,0 +1,46 @@
+# 讓社群資料支援 AI 存取 (MCP & OpenAPI) 實作計畫
+
+## Objective (目標)
+1. 讓外部的 AI 助理（如 Gemini）能夠讀取 `2026/data.json` 與 `2026/events.json` 中的資訊（免伺服器費）。
+2. 讓經過認證的 AI 助理，可以透過發送 GitHub Pull Request (PR) 的方式，協助新增活動資料。
+
+## Scope & Impact (範圍與影響)
+我們將採取雙管齊下的策略，這不會影響現有的 GitHub Pages 靜態網站運行：
+1. **OpenAPI 靜態規格**：讓支援自訂 API 網址的 AI 可以直接讀取 JSON (唯讀)。
+2. **MCP (Model Context Protocol) 伺服器腳本**：
+   - 讀取資料：透過 `npx` 在使用者本機端執行腳本來取得資料。
+   - 寫入資料：若使用者提供 `GITHUB_TOKEN`，則啟用 `propose_new_event` 工具，透過 GitHub API 發送 PR 來新增活動。
+
+## Implementation Steps (實作步驟)
+
+### 階段一：實作靜態 API (OpenAPI) - 唯讀
+1. 建立 `openapi.yaml` 檔案於專案根目錄。
+2. 定義唯讀 API 路徑：`GET /2026/data.json` 與 `GET /2026/events.json`。
+
+### 階段二：實作 MCP Server 腳本 - 讀取與 PR 寫入
+1. 建立 `mcp/` 目錄並初始化 Node.js 專案。
+2. 安裝 `@modelcontextprotocol/sdk` 與 `@octokit/rest` (處理 GitHub API)。
+3. **定義強型別與規則 (JSON Schema / Zod)**：
+   - 包含嚴格的字數限制與業務邏輯驗證。
+4. 撰寫 `mcp/index.js`，註冊以下 Tools：
+   - `get_communities`: 讀取社群資料。
+   - `get_events`: 讀取活動資料。
+   - `propose_new_event`: 
+     - (需認證) 接收符合 Schema 規則的活動資料。
+     - 伺服器端實作邏輯判斷：比對現有網站社群，如果是已知社群，使用其專屬顏色；如果是未知社群，強制指定為灰色 (例如 `#808080`)。
+     - 驗證 description 長度不能超過 20 個字。
+     - 透過 Octokit 在 GitHub 上建立一個新的 branch 並發起 PR 修改 `2026/events.json`。
+
+### 階段三：更新文件與使用說明
+1. 更新 `README.md` 加入 AI 整合章節。
+2. 說明如何設定 `GITHUB_TOKEN` 環境變數來啟用 AI 新增活動的功能。
+
+## 關於 AI 如何知道填入規則？ (Schema 範例)
+當我們定義 `propose_new_event` 時，Schema 會如此設計：
+- `date`: 必填，格式 `YYYY-MM-DD`。
+- `title`: 必填，字串。
+- `community`: 必填，字串。
+- `description`: 字串，**會特別加上 `maxLength: 20` 的限制**。如果 AI 試圖塞入超過 20 個字的介紹，系統會直接報錯拒絕。如果要換行，請使用 `<br>`。
+- `color`: 在指令描述中會告知 AI 顏色的規則，同時我們的 Node.js 腳本在收到資料準備發 PR 前，會進行**二次驗證與覆寫**：
+  - 程式碼會去查 `2026/events.json` 裡該社群曾用過的顏色。
+  - 如果該社群不在網站上，程式碼會自動把 `color` 欄位強制改成灰色 `#808080`，確保版面統一。

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -1,0 +1,218 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { Octokit } from "@octokit/rest";
+import { z } from "zod";
+import * as fs from "fs";
+import * as path from "path";
+
+// Initialize the MCP Server
+const server = new McpServer({
+    name: "kaohsiung-community-mcp",
+    version: "1.0.0",
+});
+
+// Helper to get local data paths (assuming running from /mcp or root)
+const getDataPath = (filename) => {
+    // Check if we are running in the mcp folder or root folder
+    const relativePath = fs.existsSync(path.join(process.cwd(), "2026")) 
+        ? path.join(process.cwd(), "2026", filename)
+        : path.join(process.cwd(), "..", "2026", filename);
+    return relativePath;
+};
+
+// Tool: Get Communities
+server.tool(
+    "get_communities",
+    "取得高雄技術社群清單與介紹",
+    {},
+    async () => {
+        try {
+            const dataPath = getDataPath("data.json");
+            const data = JSON.parse(fs.readFileSync(dataPath, "utf-8"));
+            return {
+                content: [{ type: "text", text: JSON.stringify(data.communities, null, 2) }]
+            };
+        } catch (error) {
+            return {
+                content: [{ type: "text", text: `讀取社群資料失敗: ${error.message}` }],
+                isError: true,
+            };
+        }
+    }
+);
+
+// Tool: Get Events
+server.tool(
+    "get_events",
+    "取得高雄技術社群活動行事曆",
+    {
+        month: z.string().optional().describe("過濾特定月份的活動 (格式: YYYY-MM)，若未提供則回傳所有活動"),
+    },
+    async ({ month }) => {
+        try {
+            const eventsPath = getDataPath("events.json");
+            const events = JSON.parse(fs.readFileSync(eventsPath, "utf-8"));
+            
+            let filteredEvents = events;
+            if (month) {
+                filteredEvents = events.filter(e => e.date.startsWith(month));
+            }
+            
+            return {
+                content: [{ type: "text", text: JSON.stringify(filteredEvents, null, 2) }]
+            };
+        } catch (error) {
+            return {
+                content: [{ type: "text", text: `讀取活動資料失敗: ${error.message}` }],
+                isError: true,
+            };
+        }
+    }
+);
+
+// Tool: Propose New Event
+server.tool(
+    "propose_new_event",
+    "建立一個 Pull Request 來新增一個社群活動",
+    {
+        date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "日期格式必須為 YYYY-MM-DD").describe("活動日期 (例如: 2026-12-25)"),
+        title: z.string().min(1, "標題不能為空").describe("活動標題"),
+        community: z.string().min(1, "社群名稱不能為空").describe("主辦社群名稱 (例如: GDG Kaohsiung)"),
+        description: z.string().max(20, "活動介紹最多 20 個字").optional().default("").describe("活動簡短介紹，絕對不能超過 20 個字"),
+        link: z.string().url("必須是有效的 URL").optional().default("").describe("活動報名或詳細資訊連結"),
+    },
+    async ({ date, title, community, description, link }) => {
+        // Check for GitHub Token
+        const token = process.env.GITHUB_TOKEN;
+        if (!token) {
+            return {
+                content: [{ type: "text", text: "錯誤: 伺服器未設定 GITHUB_TOKEN，無法發送 Pull Request。" }],
+                isError: true,
+            };
+        }
+
+        try {
+            // 1. Process Business Logic: Lookup Community Color
+            const dataPath = getDataPath("data.json");
+            let communityColor = "#808080"; // Default grey
+            
+            if (fs.existsSync(dataPath)) {
+                const data = JSON.parse(fs.readFileSync(dataPath, "utf-8"));
+                // Match by mapped name or original name in events
+                const foundCommunity = data.communities.find(c => 
+                    c.name === community || 
+                    c.name.includes(community) || 
+                    community.includes(c.name)
+                );
+                
+                if (foundCommunity && foundCommunity.color) {
+                    communityColor = foundCommunity.color;
+                }
+            }
+
+            const newEvent = {
+                date,
+                community,
+                title,
+                description,
+                link,
+                color: communityColor
+            };
+
+            // 2. GitHub API Operations
+            const octokit = new Octokit({ auth: token });
+            
+            // Note: Since this is meant to be run via npx, the user running it needs to provide
+            // the repo owner and repo name. We'll try to infer it from git config or env vars, 
+            // but for safety, we require them as ENV vars if not standard.
+            const owner = process.env.GITHUB_REPO_OWNER || "YOUR_GITHUB_USERNAME"; // Replace later in docs
+            const repo = process.env.GITHUB_REPO_NAME || "CommunityCardOrg";
+            
+            if (owner === "YOUR_GITHUB_USERNAME") {
+               return {
+                   content: [{ type: "text", text: "請設定 GITHUB_REPO_OWNER 環境變數來指定發送 PR 的目標倉庫。" }],
+                   isError: true,
+               };
+            }
+
+            // Get current events.json from main branch
+            const fileContent = await octokit.repos.getContent({
+                owner,
+                repo,
+                path: "2026/events.json",
+                ref: "main"
+            });
+
+            if (!("content" in fileContent.data)) {
+                throw new Error("Unable to read events.json from repository");
+            }
+
+            const currentEvents = JSON.parse(Buffer.from(fileContent.data.content, "base64").toString("utf-8"));
+            currentEvents.push(newEvent);
+            
+            // Sort by date just to be nice
+            currentEvents.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
+            const updatedContentBase64 = Buffer.from(JSON.stringify(currentEvents, null, 2)).toString("base64");
+
+            // Create a new branch
+            const mainRef = await octokit.git.getRef({
+                owner,
+                repo,
+                ref: "heads/main"
+            });
+            const mainSha = mainRef.data.object.sha;
+
+            const branchName = `add-event-${date.replace(/-/g, "")}-${Date.now()}`;
+            await octokit.git.createRef({
+                owner,
+                repo,
+                ref: `refs/heads/${branchName}`,
+                sha: mainSha
+            });
+
+            // Update the file in the new branch
+            await octokit.repos.createOrUpdateFileContents({
+                owner,
+                repo,
+                path: "2026/events.json",
+                message: `Add event: ${title} (${community})`,
+                content: updatedContentBase64,
+                sha: fileContent.data.sha,
+                branch: branchName
+            });
+
+            // Create the Pull Request
+            const pr = await octokit.pulls.create({
+                owner,
+                repo,
+                title: `[自動新增活動] ${title} (${community})`,
+                head: branchName,
+                base: "main",
+                body: `由 MCP AI 助理發起的活動新增請求：\n\n- 日期：${date}\n- 社群：${community}\n- 標題：${title}\n- 介紹：${description}\n- 顏色：${communityColor}`
+            });
+
+            return {
+                content: [{ type: "text", text: `成功！已建立 Pull Request: ${pr.data.html_url}` }]
+            };
+
+        } catch (error) {
+            return {
+                content: [{ type: "text", text: `發送 PR 失敗: ${error.message}` }],
+                isError: true,
+            };
+        }
+    }
+);
+
+// Start the server
+async function main() {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.log("Kaohsiung Community MCP Server running on stdio");
+}
+
+main().catch((error) => {
+    console.error("Server error:", error);
+    process.exit(1);
+});

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { Octokit } from "@octokit/rest";

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1361 @@
+{
+  "name": "mcp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@octokit/rest": "^22.0.1",
+        "zod": "^4.4.3"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.9",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.9.tgz",
+      "integrity": "sha512-o8Bi3f608eyM+7BmBiUWxFsdjLb3/ym1cQek5LZOv9KkZcxRrHCPhhRzm6xjO6HVZ85ItD6+sTsjxo821SVa/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "content-type": "^2.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,17 +1,23 @@
 {
-  "name": "mcp",
+  "name": "community-card-mcp",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mcp",
+      "name": "community-card-mcp",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@octokit/rest": "^22.0.1",
         "zod": "^4.4.3"
+      },
+      "bin": {
+        "mcp": "index.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@hono/node-server": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,15 +1,21 @@
 {
-  "name": "mcp",
+  "name": "community-card-mcp",
   "version": "1.0.0",
-  "description": "",
+  "description": "社群名牌卡 MCP 伺服器：透過 stdio 提供社群、活動查詢與發 PR 新增活動的工具",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "type": "module",
+  "bin": {
+    "mcp": "./index.js"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "type": "commonjs",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "keywords": ["mcp", "community", "kaohsiung"],
+  "author": "AndyAWD and contributors",
+  "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@octokit/rest": "^22.0.1",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "mcp",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@octokit/rest": "^22.0.1",
+    "zod": "^4.4.3"
+  }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   version: 1.0.0
 servers:
   - url: https://your-github-pages-url.github.io/CommunityCardOrg
-    description: GitHub Pages Production Server (請替換為實際網址)
+    description: GitHub Pages Production Server（fork 後請改為自己的網址，例如 https://community-card.org）
 
 paths:
   /2026/data.json:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,106 @@
+openapi: 3.1.0
+info:
+  title: Kaohsiung Community API
+  description: 提供高雄在地技術社群的介紹與活動行事曆資料。
+  version: 1.0.0
+servers:
+  - url: https://your-github-pages-url.github.io/CommunityCardOrg
+    description: GitHub Pages Production Server (請替換為實際網址)
+
+paths:
+  /2026/data.json:
+    get:
+      summary: 取得社群清單與介紹
+      description: 回傳 2026 年參與的高雄技術社群清單、贊助商與集點獎勵資訊。
+      operationId: getCommunities
+      responses:
+        '200':
+          description: 成功取得資料
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommunityData'
+
+  /2026/events.json:
+    get:
+      summary: 取得活動行事曆
+      description: 回傳各社群舉辦的活動清單。
+      operationId: getEvents
+      responses:
+        '200':
+          description: 成功取得活動資料
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+
+components:
+  schemas:
+    CommunityData:
+      type: object
+      properties:
+        communities:
+          type: array
+          items:
+            $ref: '#/components/schemas/Community'
+        sponsors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Entity'
+        rewards:
+          type: array
+          items:
+            $ref: '#/components/schemas/Entity'
+
+    Entity:
+      type: object
+      properties:
+        name:
+          type: string
+        link:
+          type: string
+          format: uri
+        logo:
+          type: string
+        description:
+          type: string
+
+    Community:
+      allOf:
+        - $ref: '#/components/schemas/Entity'
+        - type: object
+          properties:
+            color:
+              type: string
+              description: 該社群代表色的 Hex 色碼，例如 #EA4335
+
+    Event:
+      type: object
+      required:
+        - date
+        - title
+        - community
+        - color
+      properties:
+        date:
+          type: string
+          format: date
+          description: 活動日期 (YYYY-MM-DD)
+        community:
+          type: string
+          description: 主辦社群名稱
+        title:
+          type: string
+          description: 活動標題
+        description:
+          type: string
+          maxLength: 20
+          description: 活動介紹 (不超過 20 個字)
+        link:
+          type: string
+          description: 活動報名或宣傳連結
+        color:
+          type: string
+          description: 顯示在行事曆上的顏色，需對應該社群的代表色

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,6 +825,16 @@
         "fd-slicer": "~1.1.0"
       }
     },
+    "node_modules/@types/node": {
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "undici-types": "~7.21.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1206,6 +1216,13 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+      "license": "MIT",
+      "optional": true
     }
   }
 }

--- a/patch_colors.js
+++ b/patch_colors.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+
+const dataPath = '2026/data.json';
+const eventsPath = '2026/events.json';
+
+// Read files
+const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+const events = JSON.parse(fs.readFileSync(eventsPath, 'utf8'));
+
+// Extract colors from events
+const communityColors = {};
+events.forEach(event => {
+    if (event.community && event.color && !communityColors[event.community]) {
+        communityColors[event.community] = event.color;
+    }
+});
+
+// We need to match names from events.json to data.json
+// events: "GDG Kaohsiung", data: "Google Developer Groups Kaohsiung 臉書社團"
+const nameMapping = {
+    "Google Developer Groups Kaohsiung 臉書社團": "GDG Kaohsiung",
+    "開發者 Buffet Discord": "開發者 Buffet",
+    "國泰 CDC 小聚": "國泰 CDC 小聚",
+    "高雄 WordPress 小聚 Kaohsiung WordPress Meetup": "高雄 WordPress",
+    "Second Space 臉書社團": "Second Space",
+    "KaLUG 官方網站": "KaLUG",
+    "Pyladies Kaohsiung 官網": "PyLadies Kaohsiung",
+    "KIMU 高雄獨立遊戲開發者聚會 臉書社團": "KIMU - 高雄獨立遊戲開發者聚會",
+    "南台灣敏捷社群 臉書社團": "南台灣敏捷社群", // No event currently, will leave color out or default
+    "K.NET": "K.NET",
+    "VSCP 粉鳥趴": "氛圍工作者交流趴（粉鳥趴）",
+    "UIUX.Kaohsiung": "UIUX Kaohsiung",
+    "vLAB Online 台灣路由網路實驗中心": "vLAB Online"
+};
+
+// Apply colors to data.json
+data.communities = data.communities.map(community => {
+    const eventName = nameMapping[community.name];
+    if (eventName && communityColors[eventName]) {
+        return { ...community, color: communityColors[eventName] };
+    }
+    // Default color if not found in events
+    return community;
+});
+
+// Write back to data.json
+fs.writeFileSync(dataPath, JSON.stringify(data, null, 2));
+console.log('Successfully updated data.json with colors!');


### PR DESCRIPTION
## Summary

- **新增 AI 整合管道**：在 `mcp/` 加入 Node.js MCP 伺服器（提供 `get_communities`、`get_events`、`propose_new_event` 三個工具），並於根目錄新增 `openapi.yaml` 規格檔，讓 Claude、Gemini、ChatGPT、Codex 等 AI 工具能直接查詢社群資料、甚至代為發 PR 新增活動。
- **資料模型擴充**：`2026/data.json` 為每個社群新增 `color` 代表色欄位，`events.json` 的 `color` 改由社群代表色自動對應，`propose_new_event` 也會自動帶入。
- **MCP 可執行性修正**：原本 `mcp/package.json` 設成 `commonjs` 但程式碼是 ESM、又沒 `bin` 欄位，導致 README 教學的 `npx ... mcp` 必定失敗；本 PR 改為 `type: "module"`、加 `bin`，並為 `mcp/index.js` 加上 shebang 與執行權限。
- **README 大幅補齊**：新增本機開發部署、Fork 與客製化指南（10 項清單給其他城市/組織使用）、資料 Schema 速查（含 JSON 範例）、MCP 環境變數與三大 CLI（Claude Code / Gemini CLI / Codex CLI）連線驗證、印章機制、授權段落。
- **MIT LICENSE**：補上實體授權檔，版權人為 `AndyAWD and GDG Kaohsiung contributors`。
- **`openapi.yaml` server description** 補上 fork 替換提示。

## Test plan

- [ ] `cd mcp && npm install && node index.js` 應印出 `Kaohsiung Community MCP Server running on stdio`，無 ESM/CommonJS 錯誤（已本機驗證通過）。
- [ ] `npx -y github:gdg-kh/CommunityCardOrg#feature/mcp mcp` 能在外部環境啟動。
- [ ] 將 MCP 設定加入 Claude Code (`~/.claude.json` 或 `claude mcp add`)、Gemini CLI (`~/.gemini/settings.json`)、Codex CLI (`~/.codex/config.toml`)，於對話中 `/mcp` 應看到 `kaohsiung-community` 連線成功，並可呼叫 `get_events` 取回活動列表。
- [ ] 用瀏覽器開啟 `2026/index.html` 確認月曆顏色與社群代表色一致。
- [ ] 在 GitHub 上預覽 `README.md`：表格、章節層級、目錄連結（如 Fork 指南、Schema 速查）正常渲染。
- [ ] OpenAPI：用任一支援 OpenAPI 的工具載入 `openapi.yaml`，將 server URL 改為實際 GitHub Pages 網址後能 GET `/2026/events.json` 並取回 JSON。

🤖 Generated with [Claude Code](https://claude.com/claude-code)