### PR TITLE
feat(mcp): 改造 MCP 伺服器為可發佈至 npm 的獨立套件

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ npm run generate-og
 
 | # | 檔案 | 位置/欄位 | 改成什麼 |
 |---|---|---|---|
-| 1 | `README.md` | 所有 `YOUR_GITHUB_USERNAME` | 你的 GitHub 帳號或組織名稱 |
+| 1 | `README.md` | 城市名、網域、repo 路徑、社群名稱等敘述 | 改成你的城市/組織內容 |
 | 2 | `openapi.yaml` | `servers[0].url` | 你的 GitHub Pages 網址（例 `https://your-domain.com` 或 `https://yourname.github.io/YourRepo`） |
 | 3 | `CNAME` | 整個內容 | 你的自訂網域；若無自訂網域可**刪除此檔** |
 | 4 | `package.json` | `name`、`description` | 你的專案資訊 |
@@ -101,8 +101,8 @@ npm run generate-og
 | 6 | `2026/data.json` | `communities`、`sponsors`、`rewards` | 你的城市的社群資料 |
 | 7 | `2026/events.json` | 全部 | 你的城市的活動資料 |
 | 8 | `assets/stamps/` | PNG 檔 | 你的城市的印章設計 |
-| 9 | `mcp/index.js` | 第 10 行 `name: "kaohsiung-community-mcp"` | 改成你的城市，例如 `taipei-community-mcp` |
-| 10 | `mcp/package.json` | `name` | 改成例如 `taipei-community-card-mcp` |
+
+> 💡 **MCP 伺服器不需要 fork**：fork 後只需在 AI 工具的 MCP 設定中把 `COMMUNITY_CARD_DATA_URL` 環境變數指向你的 GitHub Pages 網址（例 `https://taipei-card.org/2026`），就能直接使用發佈在 npm 上的 [`community-card-mcp`](https://www.npmjs.com/package/community-card-mcp) 套件，不必修改 `mcp/` 內任何檔案或重新發佈 npm。詳見下方「2. 透過 MCP 伺服器」章節。
 
 ### 資料更新工作流
 
@@ -181,7 +181,7 @@ JSON 範例：
 
 ### 2. 透過 MCP 伺服器 (Model Context Protocol) - 適合各類 AI 開發工具
 
-我們在 `mcp/` 目錄下實作了一個 Node.js MCP 伺服器腳本。你不需要把專案 clone 下來，只需要透過 `npx` 指令就能在自己的電腦上讓 AI 工具直接連線本專案資料。
+我們在 npm 發佈了 [`community-card-mcp`](https://www.npmjs.com/package/community-card-mcp) 套件，內含一個輕量的 Node.js MCP 伺服器。你不需要 clone 專案，只要透過 `npx` 指令就能在 AI 工具中直接連線本專案資料。
 
 #### 可用工具
 
@@ -193,11 +193,12 @@ JSON 範例：
 
 #### 環境變數
 
-| 變數 | 必填 | 說明 |
-|---|---|---|
-| `GITHUB_TOKEN` | 僅 `propose_new_event` 需要 | 需有目標 repo `repo` 權限的 Personal Access Token |
-| `GITHUB_REPO_OWNER` | 僅 `propose_new_event` 需要 | 目標 repo 擁有者（例：`AndyAWD`） |
-| `GITHUB_REPO_NAME` | 僅 `propose_new_event` 需要 | 目標 repo 名稱（預設 `CommunityCardOrg`） |
+| 變數 | 必填 | 預設 | 說明 |
+|---|---|---|---|
+| `COMMUNITY_CARD_DATA_URL` | – | `https://community-card.org/2026` | 資料來源基底 URL；fork 至其他城市/組織時改成自己的網址（例 `https://taipei-card.org/2026`） |
+| `GITHUB_TOKEN` | 僅 `propose_new_event` 需要 | – | 需有目標 repo `repo` 權限的 Personal Access Token |
+| `GITHUB_REPO_OWNER` | 僅 `propose_new_event` 需要 | – | 目標 repo 擁有者（例：`gdg-kh`） |
+| `GITHUB_REPO_NAME` | 僅 `propose_new_event` 需要 | `CommunityCardOrg` | 目標 repo 名稱 |
 
 #### 安裝設定
 
@@ -208,16 +209,13 @@ JSON 範例：
 ```json
 {
   "mcpServers": {
-    "kaohsiung-community": {
+    "community-card": {
       "command": "npx",
-      "args": [
-        "-y",
-        "github:YOUR_GITHUB_USERNAME/CommunityCardOrg#main",
-        "mcp"
-      ],
+      "args": ["-y", "community-card-mcp"],
       "env": {
+        "COMMUNITY_CARD_DATA_URL": "https://community-card.org/2026",
         "GITHUB_TOKEN": "（選填）若希望 AI 能發 PR 新增活動，請填入你的 Personal Access Token",
-        "GITHUB_REPO_OWNER": "YOUR_GITHUB_USERNAME",
+        "GITHUB_REPO_OWNER": "gdg-kh",
         "GITHUB_REPO_NAME": "CommunityCardOrg"
       }
     }
@@ -225,35 +223,34 @@ JSON 範例：
 }
 ```
 
-*(⚠️ 注意：請將 `YOUR_GITHUB_USERNAME` 替換為實際存放此專案的 GitHub 帳號；fork 者請改為自己的帳號與 repo 名稱。)*
+*（高雄使用者可直接使用以上預設；fork 至其他城市/組織者請把 `COMMUNITY_CARD_DATA_URL`、`GITHUB_REPO_OWNER`、`GITHUB_REPO_NAME` 改為自己的網址與 repo。）*
 
 各工具的設定檔位置：
 
 *   **Claude Code**：執行 `claude mcp add` 互動式新增，或手動把上述 JSON 加到 `~/.claude.json`（全域）或專案的 `.mcp.json`。
 *   **Gemini CLI**：把設定加到 `~/.gemini/settings.json` 的 `mcpServers` 區塊。
-*   **Codex CLI**：把設定加到 `~/.codex/config.toml` 的 `[mcp_servers.kaohsiung-community]` 區段，或專案 `.codex/mcp.json`。
+*   **Codex CLI**：把設定加到 `~/.codex/config.toml` 的 `[mcp_servers.community-card]` 區段，或專案 `.codex/mcp.json`。
 
 #### 驗證安裝
 
 最快的本機驗證：
 
 ```bash
-cd mcp
-npm install
-node index.js
-# 應印出：Kaohsiung Community MCP Server running on stdio
+npx -y community-card-mcp
+# 應印出（stderr）：Community Card MCP Server running on stdio (data: https://community-card.org/2026)
+# 按 Ctrl+C 結束。
 ```
 
 在各 AI 工具中驗證：
 
-*   **Claude Code**：對話中輸入 `/mcp` 應看到 `kaohsiung-community` 狀態為 `connected`。
+*   **Claude Code**：對話中輸入 `/mcp` 應看到 `community-card` 狀態為 `connected`。
 *   **Gemini CLI**：輸入 `/mcp` 或 `/tools` 應列出 `get_communities`、`get_events`、`propose_new_event`。
 *   **Codex CLI**：輸入 `/mcp` 或 `mcp list` 確認連線狀態。
 
 若連線失敗，最常見原因：
 1.  Node.js 版本低於 18。
 2.  MCP 設定 JSON 格式錯誤（多了逗號、引號等）。
-3.  Fork 後忘了把 `YOUR_GITHUB_USERNAME` 改成自己的帳號，導致 `npx` 抓不到 repo。
+3.  Fork 至其他城市時，忘了把 `COMMUNITY_CARD_DATA_URL` 改成自己的 GitHub Pages 網址，AI 會抓到原始的高雄資料。
 
 ---
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,48 @@
+# community-card-mcp
+
+社群名牌卡 [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) 伺服器：透過 stdio 提供「查詢社群」、「查詢活動行事曆」、「自動發 PR 新增活動」三個工具，讓 AI 助理可以直接讀取與貢獻社群名牌卡專案的資料。
+
+預設指向 [高雄社群名牌卡](https://community-card.org)，但可透過環境變數指向任意 fork（例：台北社群卡、台中社群卡）。
+
+## 提供的工具
+
+| 工具 | 參數 | 權限 | 說明 |
+|---|---|---|---|
+| `get_communities` | 無 | 唯讀 | 取得社群清單與介紹 |
+| `get_events` | `month`（選填，`YYYY-MM`） | 唯讀 | 取得活動行事曆，可依月份過濾 |
+| `propose_new_event` | `date`、`title`、`community`、`description`（≤20 字）、`link` | 需 GitHub Token | 在指定 repo 自動建立 PR 新增活動 |
+
+## 環境變數
+
+| 變數 | 必填 | 預設 | 說明 |
+|---|---|---|---|
+| `COMMUNITY_CARD_DATA_URL` | – | `https://community-card.org/2026` | 資料來源基底 URL；fork 至其他城市時改成自己的網址 |
+| `GITHUB_TOKEN` | 僅 `propose_new_event` 需要 | – | 對目標 repo 有 `repo` 權限的 Personal Access Token |
+| `GITHUB_REPO_OWNER` | 僅 `propose_new_event` 需要 | – | 目標 repo 擁有者（例：`gdg-kh`） |
+| `GITHUB_REPO_NAME` | 僅 `propose_new_event` 需要 | `CommunityCardOrg` | 目標 repo 名稱 |
+
+## 在 AI 工具中使用
+
+把以下設定寫入各 AI 工具的 MCP 設定檔即可（不需要 clone repo）：
+
+```json
+{
+  "mcpServers": {
+    "community-card": {
+      "command": "npx",
+      "args": ["-y", "community-card-mcp"],
+      "env": {
+        "GITHUB_TOKEN": "（選填）若希望 AI 能發 PR 新增活動，請填入 Personal Access Token",
+        "GITHUB_REPO_OWNER": "gdg-kh",
+        "GITHUB_REPO_NAME": "CommunityCardOrg"
+      }
+    }
+  }
+}
+```
+
+各工具設定檔位置與完整教學請見 [主專案 README](https://github.com/gdg-kh/CommunityCardOrg#-給-ai-助理與開發者的整合指南-ai-integrations)。
+
+## License
+
+MIT — see [LICENSE](https://github.com/gdg-kh/CommunityCardOrg/blob/main/LICENSE) in the main repo.

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -3,33 +3,30 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { Octokit } from "@octokit/rest";
 import { z } from "zod";
-import * as fs from "fs";
-import * as path from "path";
 
-// Initialize the MCP Server
 const server = new McpServer({
-    name: "kaohsiung-community-mcp",
+    name: "community-card-mcp",
     version: "1.0.0",
 });
 
-// Helper to get local data paths (assuming running from /mcp or root)
-const getDataPath = (filename) => {
-    // Check if we are running in the mcp folder or root folder
-    const relativePath = fs.existsSync(path.join(process.cwd(), "2026")) 
-        ? path.join(process.cwd(), "2026", filename)
-        : path.join(process.cwd(), "..", "2026", filename);
-    return relativePath;
-};
+const DATA_BASE_URL = process.env.COMMUNITY_CARD_DATA_URL || "https://community-card.org/2026";
 
-// Tool: Get Communities
+async function fetchData(filename) {
+    const url = `${DATA_BASE_URL}/${filename}`;
+    const res = await fetch(url);
+    if (!res.ok) {
+        throw new Error(`HTTP ${res.status} fetching ${url}`);
+    }
+    return res.json();
+}
+
 server.tool(
     "get_communities",
-    "取得高雄技術社群清單與介紹",
+    "取得社群清單與介紹",
     {},
     async () => {
         try {
-            const dataPath = getDataPath("data.json");
-            const data = JSON.parse(fs.readFileSync(dataPath, "utf-8"));
+            const data = await fetchData("data.json");
             return {
                 content: [{ type: "text", text: JSON.stringify(data.communities, null, 2) }]
             };
@@ -42,23 +39,18 @@ server.tool(
     }
 );
 
-// Tool: Get Events
 server.tool(
     "get_events",
-    "取得高雄技術社群活動行事曆",
+    "取得社群活動行事曆",
     {
         month: z.string().optional().describe("過濾特定月份的活動 (格式: YYYY-MM)，若未提供則回傳所有活動"),
     },
     async ({ month }) => {
         try {
-            const eventsPath = getDataPath("events.json");
-            const events = JSON.parse(fs.readFileSync(eventsPath, "utf-8"));
-            
-            let filteredEvents = events;
-            if (month) {
-                filteredEvents = events.filter(e => e.date.startsWith(month));
-            }
-            
+            const events = await fetchData("events.json");
+            const filteredEvents = month
+                ? events.filter(e => e.date.startsWith(month))
+                : events;
             return {
                 content: [{ type: "text", text: JSON.stringify(filteredEvents, null, 2) }]
             };
@@ -71,7 +63,6 @@ server.tool(
     }
 );
 
-// Tool: Propose New Event
 server.tool(
     "propose_new_event",
     "建立一個 Pull Request 來新增一個社群活動",
@@ -83,7 +74,6 @@ server.tool(
         link: z.string().url("必須是有效的 URL").optional().default("").describe("活動報名或詳細資訊連結"),
     },
     async ({ date, title, community, description, link }) => {
-        // Check for GitHub Token
         const token = process.env.GITHUB_TOKEN;
         if (!token) {
             return {
@@ -93,22 +83,19 @@ server.tool(
         }
 
         try {
-            // 1. Process Business Logic: Lookup Community Color
-            const dataPath = getDataPath("data.json");
-            let communityColor = "#808080"; // Default grey
-            
-            if (fs.existsSync(dataPath)) {
-                const data = JSON.parse(fs.readFileSync(dataPath, "utf-8"));
-                // Match by mapped name or original name in events
-                const foundCommunity = data.communities.find(c => 
-                    c.name === community || 
-                    c.name.includes(community) || 
+            let communityColor = "#808080";
+            try {
+                const data = await fetchData("data.json");
+                const foundCommunity = data.communities.find(c =>
+                    c.name === community ||
+                    c.name.includes(community) ||
                     community.includes(c.name)
                 );
-                
                 if (foundCommunity && foundCommunity.color) {
                     communityColor = foundCommunity.color;
                 }
+            } catch {
+                // 查不到顏色就 fallback 預設灰色，不阻斷 PR 建立
             }
 
             const newEvent = {
@@ -120,23 +107,17 @@ server.tool(
                 color: communityColor
             };
 
-            // 2. GitHub API Operations
             const octokit = new Octokit({ auth: token });
-            
-            // Note: Since this is meant to be run via npx, the user running it needs to provide
-            // the repo owner and repo name. We'll try to infer it from git config or env vars, 
-            // but for safety, we require them as ENV vars if not standard.
-            const owner = process.env.GITHUB_REPO_OWNER || "YOUR_GITHUB_USERNAME"; // Replace later in docs
+            const owner = process.env.GITHUB_REPO_OWNER;
             const repo = process.env.GITHUB_REPO_NAME || "CommunityCardOrg";
-            
-            if (owner === "YOUR_GITHUB_USERNAME") {
+
+            if (!owner) {
                return {
                    content: [{ type: "text", text: "請設定 GITHUB_REPO_OWNER 環境變數來指定發送 PR 的目標倉庫。" }],
                    isError: true,
                };
             }
 
-            // Get current events.json from main branch
             const fileContent = await octokit.repos.getContent({
                 owner,
                 repo,
@@ -150,13 +131,10 @@ server.tool(
 
             const currentEvents = JSON.parse(Buffer.from(fileContent.data.content, "base64").toString("utf-8"));
             currentEvents.push(newEvent);
-            
-            // Sort by date just to be nice
             currentEvents.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 
             const updatedContentBase64 = Buffer.from(JSON.stringify(currentEvents, null, 2)).toString("base64");
 
-            // Create a new branch
             const mainRef = await octokit.git.getRef({
                 owner,
                 repo,
@@ -172,7 +150,6 @@ server.tool(
                 sha: mainSha
             });
 
-            // Update the file in the new branch
             await octokit.repos.createOrUpdateFileContents({
                 owner,
                 repo,
@@ -183,7 +160,6 @@ server.tool(
                 branch: branchName
             });
 
-            // Create the Pull Request
             const pr = await octokit.pulls.create({
                 owner,
                 repo,
@@ -206,11 +182,10 @@ server.tool(
     }
 );
 
-// Start the server
 async function main() {
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.log("Kaohsiung Community MCP Server running on stdio");
+    console.error(`Community Card MCP Server running on stdio (data: ${DATA_BASE_URL})`);
 }
 
 main().catch((error) => {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -5,16 +5,29 @@
   "main": "index.js",
   "type": "module",
   "bin": {
-    "mcp": "./index.js"
+    "community-card-mcp": "./index.js"
   },
   "scripts": {
     "start": "node index.js"
   },
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gdg-kh/CommunityCardOrg.git",
+    "directory": "mcp"
+  },
+  "homepage": "https://github.com/gdg-kh/CommunityCardOrg#readme",
+  "bugs": {
+    "url": "https://github.com/gdg-kh/CommunityCardOrg/issues"
+  },
   "engines": {
     "node": ">=18.0.0"
   },
-  "keywords": ["mcp", "community", "kaohsiung"],
-  "author": "AndyAWD and contributors",
+  "keywords": ["mcp", "community", "kaohsiung", "gdg"],
+  "author": "AndyAWD and GDG Kaohsiung contributors",
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary
讓 `mcp/` 變成可以透過 `npx -y community-card-mcp` 直接執行的 npm 套件，並修掉先前隱藏的 bug。

### 主要變更
- **資料來源改 HTTPS**：原本 `get_communities` / `get_events` / `propose_new_event` 都靠 `fs.readFileSync(process.cwd()/2026/...)` 讀本地檔案，這代表 npm 安裝後在使用者家目錄執行時會壞掉。改為從 GitHub Pages 透過 `fetch` 抓資料，並新增 `COMMUNITY_CARD_DATA_URL` 環境變數讓 fork 至其他城市的人可以指向自己的網址。
- **修 stdio 汙染**：`console.log(...)` 改成 `console.error(...)`，避免人類訊息混進 JSON-RPC 通道。
- **命名對齊**：MCP server name 由 `kaohsiung-community-mcp` 改為 `community-card-mcp` 對應套件名；bin 名由通用的 `mcp` 改為 `community-card-mcp`。
- **npm metadata**：`mcp/package.json` 補 `repository` / `homepage` / `bugs` / `files`，新增 `mcp/README.md` 作為 npm 套件頁說明。
- **主 README**：第 2 節改用 `npx -y community-card-mcp` 指令、補上 `COMMUNITY_CARD_DATA_URL` 環境變數；Fork 客製化清單移除 `mcp/*` 兩列並補上「MCP 不需要 fork、只要設環境變數」的指引。

### 後續
PR 合併前我會跑 `npm publish`，讓套件實際存在於 npm registry。已本機驗證：
- `node --check index.js` 通過
- `node index.js < /dev/null` 確認 boot 訊息走 stderr：`Community Card MCP Server running on stdio (data: https://community-card.org/2026)`
- `npm pack --dry-run` 確認封裝只有 3 個檔案（package.json / index.js / README.md，共 3.8 kB）
- 直接 `fetch()` data.json / events.json 都 200 OK

## Test plan
- [ ] 本機跑 `npx -y community-card-mcp`（合併後）能啟動並顯示正確 boot 訊息
- [ ] 在 Claude Code / Gemini CLI / Codex CLI 任一個工具掛載後 `/mcp` 應顯示 connected
- [ ] 呼叫 `get_communities` 回傳 13 個社群、`get_events` 回傳 118 個活動
- [ ] 設 `COMMUNITY_CARD_DATA_URL=https://community-card.org/2026` 與不設都能運作
- [ ] 用測試帳號 token 跑 `propose_new_event` 確認能開 PR 並抓到正確社群顏色

🤖 Generated with [Claude Code](https://claude.com/claude-code)