### PR TITLE
feat(mcp): 新增贊助商與集章獎勵的 MCP 工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Fork 後若只是要定期維護自家社群的活動，建議流程：
 
 **B. 透過 MCP 伺服器（推薦，適合穩定整合）**
 
-若希望 AI 能直接呼叫專屬工具（`get_communities`、`get_events`），甚至自動發 PR 新增活動（`propose_new_event`），請參考下方「2. 透過 MCP 伺服器」章節的設定步驟。
+若希望 AI 能直接呼叫專屬工具（`get_communities`、`get_events`、`get_sponsors`、`get_rewards`），甚至自動發 PR 新增活動／贊助商／集章獎勵（`propose_new_event`、`propose_new_sponsor`、`propose_new_reward`），請參考下方「2. 透過 MCP 伺服器」章節的設定步驟。
 
 > ⚠️ 注意：目前主流 AI CLI 工具（Claude Code / Gemini CLI / Codex CLI）**沒有原生「匯入 OpenAPI 規格作為 Action」的 UI**。`openapi.yaml` 在本專案的角色是給 AI 與 MCP 伺服器**參照欄位定義**，不是被當成可呼叫的動作清單匯入。
 
@@ -152,8 +152,8 @@ Fork 後若只是要定期維護自家社群的活動，建議流程：
 | | `logo` | string | ✓ | Logo 圖檔路徑或 URL |
 | | `description` | string | ✓ | 社群介紹 |
 | | `color` | string | ✓ | hex 代表色，例如 `#EA4335` |
-| `sponsors[]` | `name` / `link` / `logo` / `description` | string | – | 贊助商（同上但無 `color`） |
-| `rewards[]` | `name` / `link` / `logo` / `description` | string | – | 集章獎勵項目 |
+| `sponsors[]` | `name` / `link` / `logo` / `description` | string | ✓ | 贊助商（同上但無 `color`） |
+| `rewards[]` | `name` / `link` / `logo` / `description` | string | ✓ | 集章獎勵項目 |
 
 **`/2026/events.json`**（陣列，每筆為一個活動物件）：
 
@@ -189,16 +189,20 @@ JSON 範例：
 |---|---|---|---|
 | `get_communities` | 無 | 唯讀 | 取得社群清單與介紹 |
 | `get_events` | `month`（選填，格式 `YYYY-MM`） | 唯讀 | 取得活動行事曆，可依月份過濾 |
+| `get_sponsors` | 無 | 唯讀 | 取得贊助商清單 |
+| `get_rewards` | 無 | 唯讀 | 取得集章獎勵清單 |
 | `propose_new_event` | `date`、`title`、`community`、`description`（≤20 字）、`link` | **需 GitHub Token** | 自動建立 PR 新增活動 |
+| `propose_new_sponsor` | `name`、`link`、`logo`、`description` | **需 GitHub Token** | 自動建立 PR 新增贊助商 |
+| `propose_new_reward` | `name`、`link`、`logo`、`description` | **需 GitHub Token** | 自動建立 PR 新增集章獎勵項目 |
 
 #### 環境變數
 
 | 變數 | 必填 | 預設 | 說明 |
 |---|---|---|---|
 | `COMMUNITY_CARD_DATA_URL` | – | `https://community-card.org/2026` | 資料來源基底 URL；fork 至其他城市/組織時改成自己的網址（例 `https://taipei-card.org/2026`） |
-| `GITHUB_TOKEN` | 僅 `propose_new_event` 需要 | – | 需有目標 repo `repo` 權限的 Personal Access Token |
-| `GITHUB_REPO_OWNER` | 僅 `propose_new_event` 需要 | – | 目標 repo 擁有者（例：`gdg-kh`） |
-| `GITHUB_REPO_NAME` | 僅 `propose_new_event` 需要 | `CommunityCardOrg` | 目標 repo 名稱 |
+| `GITHUB_TOKEN` | 僅 `propose_*` 工具需要 | – | 需有目標 repo `repo` 權限的 Personal Access Token |
+| `GITHUB_REPO_OWNER` | 僅 `propose_*` 工具需要 | – | 目標 repo 擁有者（例：`gdg-kh`） |
+| `GITHUB_REPO_NAME` | 僅 `propose_*` 工具需要 | `CommunityCardOrg` | 目標 repo 名稱 |
 
 #### 安裝設定
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,6 @@
 # community-card-mcp
 
-社群名牌卡 [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) 伺服器：透過 stdio 提供「查詢社群」、「查詢活動行事曆」、「自動發 PR 新增活動」三個工具，讓 AI 助理可以直接讀取與貢獻社群名牌卡專案的資料。
+社群名牌卡 [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) 伺服器：透過 stdio 提供「查詢社群／活動／贊助商／集章獎勵」與「自動發 PR 新增活動／贊助商／集章獎勵」共七個工具，讓 AI 助理可以直接讀取與貢獻社群名牌卡專案的資料。
 
 預設指向 [高雄社群名牌卡](https://community-card.org)，但可透過環境變數指向任意 fork（例：台北社群卡、台中社群卡）。
 
@@ -10,16 +10,20 @@
 |---|---|---|---|
 | `get_communities` | 無 | 唯讀 | 取得社群清單與介紹 |
 | `get_events` | `month`（選填，`YYYY-MM`） | 唯讀 | 取得活動行事曆，可依月份過濾 |
+| `get_sponsors` | 無 | 唯讀 | 取得贊助商清單 |
+| `get_rewards` | 無 | 唯讀 | 取得集章獎勵清單 |
 | `propose_new_event` | `date`、`title`、`community`、`description`（≤20 字）、`link` | 需 GitHub Token | 在指定 repo 自動建立 PR 新增活動 |
+| `propose_new_sponsor` | `name`、`link`、`logo`、`description` | 需 GitHub Token | 自動建立 PR 新增贊助商 |
+| `propose_new_reward` | `name`、`link`、`logo`、`description` | 需 GitHub Token | 自動建立 PR 新增集章獎勵項目 |
 
 ## 環境變數
 
 | 變數 | 必填 | 預設 | 說明 |
 |---|---|---|---|
 | `COMMUNITY_CARD_DATA_URL` | – | `https://community-card.org/2026` | 資料來源基底 URL；fork 至其他城市時改成自己的網址 |
-| `GITHUB_TOKEN` | 僅 `propose_new_event` 需要 | – | 對目標 repo 有 `repo` 權限的 Personal Access Token |
-| `GITHUB_REPO_OWNER` | 僅 `propose_new_event` 需要 | – | 目標 repo 擁有者（例：`gdg-kh`） |
-| `GITHUB_REPO_NAME` | 僅 `propose_new_event` 需要 | `CommunityCardOrg` | 目標 repo 名稱 |
+| `GITHUB_TOKEN` | 僅 `propose_*` 工具需要 | – | 對目標 repo 有 `repo` 權限的 Personal Access Token |
+| `GITHUB_REPO_OWNER` | 僅 `propose_*` 工具需要 | – | 目標 repo 擁有者（例：`gdg-kh`） |
+| `GITHUB_REPO_NAME` | 僅 `propose_*` 工具需要 | `CommunityCardOrg` | 目標 repo 名稱 |
 
 ## 在 AI 工具中使用
 

--- a/mcp/index.js
+++ b/mcp/index.js
@@ -64,6 +64,167 @@ server.tool(
 );
 
 server.tool(
+    "get_sponsors",
+    "取得贊助商清單",
+    {},
+    async () => {
+        try {
+            const data = await fetchData("data.json");
+            return {
+                content: [{ type: "text", text: JSON.stringify(data.sponsors, null, 2) }]
+            };
+        } catch (error) {
+            return {
+                content: [{ type: "text", text: `讀取贊助商資料失敗: ${error.message}` }],
+                isError: true,
+            };
+        }
+    }
+);
+
+server.tool(
+    "get_rewards",
+    "取得集章獎勵清單",
+    {},
+    async () => {
+        try {
+            const data = await fetchData("data.json");
+            return {
+                content: [{ type: "text", text: JSON.stringify(data.rewards, null, 2) }]
+            };
+        } catch (error) {
+            return {
+                content: [{ type: "text", text: `讀取集章獎勵資料失敗: ${error.message}` }],
+                isError: true,
+            };
+        }
+    }
+);
+
+async function proposeDataJsonPullRequest({ section, newItem, branchPrefix, prTitle, commitMessage, prBody }) {
+    const token = process.env.GITHUB_TOKEN;
+    if (!token) {
+        return {
+            content: [{ type: "text", text: "錯誤: 伺服器未設定 GITHUB_TOKEN，無法發送 Pull Request。" }],
+            isError: true,
+        };
+    }
+
+    const owner = process.env.GITHUB_REPO_OWNER;
+    const repo = process.env.GITHUB_REPO_NAME || "CommunityCardOrg";
+    if (!owner) {
+        return {
+            content: [{ type: "text", text: "請設定 GITHUB_REPO_OWNER 環境變數來指定發送 PR 的目標倉庫。" }],
+            isError: true,
+        };
+    }
+
+    try {
+        const octokit = new Octokit({ auth: token });
+
+        const fileContent = await octokit.repos.getContent({
+            owner,
+            repo,
+            path: "2026/data.json",
+            ref: "main"
+        });
+        if (!("content" in fileContent.data)) {
+            throw new Error("Unable to read 2026/data.json from repository");
+        }
+
+        const currentData = JSON.parse(Buffer.from(fileContent.data.content, "base64").toString("utf-8"));
+        if (!Array.isArray(currentData[section])) {
+            throw new Error(`data.json 中找不到 ${section} 陣列`);
+        }
+        currentData[section].push(newItem);
+
+        const updatedContentBase64 = Buffer.from(JSON.stringify(currentData, null, 2)).toString("base64");
+
+        const mainRef = await octokit.git.getRef({ owner, repo, ref: "heads/main" });
+        const mainSha = mainRef.data.object.sha;
+
+        const slug = (newItem.name || section).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || section;
+        const branchName = `${branchPrefix}-${slug}-${Date.now()}`;
+        await octokit.git.createRef({
+            owner,
+            repo,
+            ref: `refs/heads/${branchName}`,
+            sha: mainSha
+        });
+
+        await octokit.repos.createOrUpdateFileContents({
+            owner,
+            repo,
+            path: "2026/data.json",
+            message: commitMessage,
+            content: updatedContentBase64,
+            sha: fileContent.data.sha,
+            branch: branchName
+        });
+
+        const pr = await octokit.pulls.create({
+            owner,
+            repo,
+            title: prTitle,
+            head: branchName,
+            base: "main",
+            body: prBody
+        });
+
+        return {
+            content: [{ type: "text", text: `成功！已建立 Pull Request: ${pr.data.html_url}` }]
+        };
+    } catch (error) {
+        return {
+            content: [{ type: "text", text: `發送 PR 失敗: ${error.message}` }],
+            isError: true,
+        };
+    }
+}
+
+server.tool(
+    "propose_new_sponsor",
+    "建立一個 Pull Request 來新增一個贊助商",
+    {
+        name: z.string().min(1, "名稱不能為空").describe("贊助商名稱"),
+        link: z.string().url("必須是有效的 URL").describe("贊助商官網或介紹頁連結"),
+        logo: z.string().min(1, "logo 路徑不能為空").describe("贊助商 logo 相對路徑，例如 ../assets/sponsor_xxx.png"),
+        description: z.string().optional().default("").describe("贊助商簡介，可包含 <br> 換行"),
+    },
+    async ({ name, link, logo, description }) => {
+        return proposeDataJsonPullRequest({
+            section: "sponsors",
+            newItem: { name, link, logo, description },
+            branchPrefix: "add-sponsor",
+            prTitle: `[自動新增贊助商] ${name}`,
+            commitMessage: `Add sponsor: ${name}`,
+            prBody: `由 MCP AI 助理發起的贊助商新增請求：\n\n- 名稱：${name}\n- 連結：${link}\n- Logo：${logo}\n- 介紹：${description}`
+        });
+    }
+);
+
+server.tool(
+    "propose_new_reward",
+    "建立一個 Pull Request 來新增一個集章獎勵項目",
+    {
+        name: z.string().min(1, "名稱不能為空").describe("獎勵項目名稱"),
+        link: z.string().url("必須是有效的 URL").describe("獎勵說明或活動連結"),
+        logo: z.string().min(1, "logo 路徑不能為空").describe("獎勵 logo 相對路徑，例如 ../assets/rewards_xxx.png"),
+        description: z.string().optional().default("").describe("獎勵說明，可包含 <br> 換行"),
+    },
+    async ({ name, link, logo, description }) => {
+        return proposeDataJsonPullRequest({
+            section: "rewards",
+            newItem: { name, link, logo, description },
+            branchPrefix: "add-reward",
+            prTitle: `[自動新增集章獎勵] ${name}`,
+            commitMessage: `Add reward: ${name}`,
+            prBody: `由 MCP AI 助理發起的集章獎勵新增請求：\n\n- 名稱：${name}\n- 連結：${link}\n- Logo：${logo}\n- 介紹：${description}`
+        });
+    }
+);
+
+server.tool(
     "propose_new_event",
     "建立一個 Pull Request 來新增一個社群活動",
     {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "community-card-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "社群名牌卡 MCP 伺服器：透過 stdio 提供社群、活動查詢與發 PR 新增活動的工具",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- 新增 4 個 MCP 工具：`get_sponsors`、`get_rewards`、`propose_new_sponsor`、`propose_new_reward`，讓 AI 助理可以讀取與貢獻 `2026/sponsors.html` 與 `2026/rewards.html` 對應的資料
- 抽出 `proposeDataJsonPullRequest` helper 集中處理 `2026/data.json` 的 PR 流程；現有 `propose_new_event`（操作 `events.json`）暫不重構以控制範圍
- `mcp/package.json` 版本 `1.0.0` → `1.1.0`（semver minor，向後相容新增功能）
- 同步更新 `mcp/README.md` 與主 `README.md` 的工具表、環境變數備註（`propose_*` 統稱），以及 `data.json` schema 表的必填標記

合併後將在 `mcp/` 目錄手動 `npm publish` 發佈 `community-card-mcp@1.1.0`。

## Test plan
- [x] 本地 `node mcp/index.js` 透過 JSON-RPC `tools/list` 確認 7 個工具皆已註冊
- [x] 呼叫 `get_sponsors` / `get_rewards` 回傳資料數量與 `https://community-card.org/2026/data.json` 一致
- [ ] 在測試 repo 設好 `GITHUB_TOKEN` / `GITHUB_REPO_OWNER` 後跑 `propose_new_sponsor`、`propose_new_reward`，確認新建分支只動到對應陣列、PR 標題與 body 正確
- [ ] 回歸：`get_communities`、`get_events`、`propose_new_event` 維持原行為
- [ ] 確認 `2026/sponsors.html`、`2026/rewards.html` 讀取 `data.json` 仍正常顯示

🤖 Generated with [Claude Code](https://claude.com/claude-code)