### PR TITLE
feat: 自動為外連加上 UTM 追蹤碼

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,42 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Inject UTM tracking into events.json / data.json
+        run: node scripts/add-tracking.mjs
+      - name: Strip node_modules before upload
+        run: rm -rf node_modules
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "高雄社群名牌卡 - 社群月曆 OG 圖生成",
   "type": "module",
   "scripts": {
-    "generate-og": "node scripts/generate-og-images.js"
+    "generate-og": "node scripts/generate-og-images.js",
+    "build:tracking": "node scripts/add-tracking.mjs"
   },
   "dependencies": {
     "puppeteer": "^23.0.0"

--- a/scripts/add-tracking.mjs
+++ b/scripts/add-tracking.mjs
@@ -1,0 +1,98 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const TARGETS = ["2026/events.json", "2026/data.json"];
+const UTM = {
+  utm_source: "community-card.org",
+  utm_medium: "referral",
+  utm_campaign: "community-card",
+};
+const UTM_KEYS = new Set(Object.keys(UTM));
+
+const errors = [];
+let added = 0;
+let skippedPlaceholder = 0;
+let preservedExistingUtm = 0;
+let skippedNonHttp = 0;
+
+function verify(original, transformed, context) {
+  const a = new URL(original);
+  const b = new URL(transformed);
+  if (a.origin !== b.origin)
+    errors.push(`[${context}] origin 變動: ${a.origin} → ${b.origin}`);
+  if (a.pathname !== b.pathname)
+    errors.push(`[${context}] pathname 變動: ${a.pathname} → ${b.pathname}`);
+  if (a.hash !== b.hash)
+    errors.push(`[${context}] hash 變動: ${a.hash} → ${b.hash}`);
+  for (const [k, v] of a.searchParams) {
+    if (b.searchParams.get(k) !== v)
+      errors.push(
+        `[${context}] 既有參數 ${k} 變動: ${v} → ${b.searchParams.get(k)}`,
+      );
+  }
+  const newKeys = [...b.searchParams.keys()].filter((k) => !a.searchParams.has(k));
+  const unexpected = newKeys.filter((k) => !UTM_KEYS.has(k));
+  if (unexpected.length)
+    errors.push(`[${context}] 新增非預期參數: ${unexpected.join(",")}`);
+}
+
+function addTrackingParams(link, context) {
+  if (!link || link === "#") {
+    skippedPlaceholder++;
+    return link;
+  }
+  let url;
+  try {
+    url = new URL(link);
+  } catch {
+    errors.push(`[${context}] 無法解析 URL: ${link}`);
+    return link;
+  }
+  if (!/^https?:$/.test(url.protocol)) {
+    skippedNonHttp++;
+    return link;
+  }
+  if (url.searchParams.has("utm_source")) {
+    preservedExistingUtm++;
+    return link;
+  }
+  for (const [k, v] of Object.entries(UTM)) url.searchParams.set(k, v);
+  const result = url.toString();
+  verify(link, result, context);
+  added++;
+  return result;
+}
+
+function walk(node, path) {
+  if (Array.isArray(node)) return node.map((n, i) => walk(n, `${path}[${i}]`));
+  if (node && typeof node === "object") {
+    const out = {};
+    for (const [k, v] of Object.entries(node)) {
+      out[k] =
+        k === "link" && typeof v === "string"
+          ? addTrackingParams(v, `${path}.link`)
+          : walk(v, `${path}.${k}`);
+    }
+    return out;
+  }
+  return node;
+}
+
+for (const file of TARGETS) {
+  const data = JSON.parse(await readFile(file, "utf8"));
+  const transformed = walk(data, file);
+  await writeFile(file, JSON.stringify(transformed, null, 2) + "\n");
+}
+
+console.log(
+  `加入 UTM: ${added}，` +
+    `保留既有 utm_source: ${preservedExistingUtm}，` +
+    `略過 '#' / 空: ${skippedPlaceholder}，` +
+    `略過非 http(s): ${skippedNonHttp}`,
+);
+
+if (errors.length) {
+  console.error(`\n驗證失敗（${errors.length} 筆）：`);
+  for (const e of errors) console.error("  -", e);
+  process.exit(1);
+}
+console.log("驗證通過：所有連結 origin / pathname / hash / 既有參數皆未變動");


### PR DESCRIPTION
## Summary
- 新增 `scripts/add-tracking.mjs`：遞迴改寫 `2026/events.json`、`2026/data.json` 中所有 `link` 欄位，加上 `utm_source=community-card.org`、`utm_medium=referral`、`utm_campaign=community-card`
- 新增 `.github/workflows/deploy-pages.yml`：把 Pages 從 legacy「Deploy from branch」改成 Actions 部署。build 階段才就地改寫，**repo 內 json 永遠保持乾淨**，main 不會出現 auto-commit
- `package.json` 加 `npm run build:tracking`

## 邊界處理（已驗證）
- `link === "#"`、空、`undefined` → 原值
- 非 `http(s):` → 原值
- 已含 `utm_source` 的連結（例：events 2/21「初五過年聚會」帶 `?utm_source=kalug.tw/`）→ 不覆寫
- 既有 query 參數值不變，只新增三個 utm_*
- 任何 origin / pathname / hash / 既有參數異動 → 腳本 `exit 1` → CI fail → 不會部署

## 本機驗證結果
```
加入 UTM: 157，保留既有 utm_source: 1，略過 '#' / 空: 1，略過非 http(s): 0
驗證通過：所有連結 origin / pathname / hash / 既有參數皆未變動
```

## 合併後需要做的事
1. 確認本 PR 跑出 Actions 預覽 / 合併
2. 切 Pages source 從 branch 改為 Actions：
   ```bash
   gh api -X PUT repos/gdg-kh/CommunityCardOrg/pages -f build_type=workflow
   ```
3. 觀察 deploy workflow 跑綠，開 https://community-card.org/2026/calendar.html hover 連結確認 UTM

## Test plan
- [ ] CI 跑綠（structural verification 不報錯）
- [ ] 合併後 Pages source 切到 Actions
- [ ] 首次 Actions 部署成功
- [ ] 線上 hover 連結帶 `?utm_source=community-card.org&utm_medium=referral&utm_campaign=community-card`
- [ ] 抽驗 kktix、luma、accupass、meetup、gdg.community.dev、facebook 各一條 HTTP 連通