### PR TITLE
fix: workflow node-version 改用 22

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       - name: Inject UTM tracking into events.json / data.json
         run: node scripts/add-tracking.mjs
       - name: Strip node_modules before upload


### PR DESCRIPTION
把 deploy-pages.yml 的 `node-version` 從 "20" 改成 "22"，消除 Node 20 deprecation 警告。腳本只用 Node 內建 fs/URL，Node 22 完全相容。